### PR TITLE
Make the display buttons to grant/revoke superuser visible

### DIFF
--- a/lib/email_notification_system/accounts/user.ex
+++ b/lib/email_notification_system/accounts/user.ex
@@ -49,7 +49,7 @@ defmodule EmailNotificationSystem.Accounts.User do
   defp normalize_msisdn(msisdn) do
     digits = String.replace(msisdn, ~r/\D/, "")
     cond do
-      String.starts_with?(digits, "254") -> "+" <> digits                       # already intl without '+'
+      String.starts_with?(digits, "254") -> "+" <> digits
       String.starts_with?(digits, "0")   -> "+254" <> binary_part(digits, 1, byte_size(digits)-1)
       true                               -> "+" <> digits
     end

--- a/lib/email_notification_system_web/live/admin/admin_users_live.ex
+++ b/lib/email_notification_system_web/live/admin/admin_users_live.ex
@@ -153,8 +153,21 @@ defmodule EmailNotificationSystemWeb.Admin.AdminUsersLive do
                 </div>
 
                 <div class="flex items-center space-x-2">
-                  <%!-- Superuser-only actions (not on self, not on other superusers) --%>
-                  <%= if @current_user.access_level == "superuser" and @current_user.id != user.id and user.access_level != "superuser" do %>
+                  <%= if @current_user.access_level == "superuser" and @current_user.id != user.id do %>
+                    <%= if user.access_level == "admin" do %>
+                      <button phx-click="grant_superuser" phx-value-id={user.id}
+                              class="px-3 py-2 border rounded-lg text-sm bg-indigo-600 hover:bg-indigo-700 text-white">
+                        Make superuser
+                      </button>
+                    <% end %>
+
+                    <%= if user.access_level == "superuser" do %>
+                      <button phx-click="revoke_superuser" phx-value-id={user.id}
+                              class="px-3 py-2 border rounded-lg text-sm hover:bg-gray-50">
+                        Revoke superuser
+                      </button>
+                    <% end %>
+
                     <%= if user.plan_type == "gold" do %>
                       <button phx-click="downgrade_plan" phx-value-id={user.id}
                               class="px-3 py-2 border rounded-lg text-sm hover:bg-gray-50">

--- a/lib/email_notification_system_web/live/compose_email_live.ex
+++ b/lib/email_notification_system_web/live/compose_email_live.ex
@@ -29,7 +29,7 @@ defmodule EmailNotificationSystemWeb.ComposeEmailLive do
         form: form,
         contacts: contacts,
         groups: groups,
-        selected_contacts: [],   # list, not MapSet
+        selected_contacts: [],
         selected_group: nil,
         email_type: "single",
         show_recipients: false
@@ -80,9 +80,6 @@ defmodule EmailNotificationSystemWeb.ComposeEmailLive do
 
   defp send_single_email(email_params, socket) do
     if length(socket.assigns.selected_contacts) == 1 do
-      # contact_id = hd(socket.assigns.selected_contacts)
-      # contact = Enum.find(socket.assigns.contacts, &(&1.id == contact_id))
-
       contact_id = hd(socket.assigns.selected_contacts)
       contact = Enum.find(socket.assigns.contacts, &(&1.id == contact_id))
 
@@ -109,9 +106,6 @@ defmodule EmailNotificationSystemWeb.ComposeEmailLive do
 
   defp send_bulk_email(email_params, socket) do
     if length(socket.assigns.selected_contacts) > 1 do
-      # contacts = Enum.filter(socket.assigns.contacts,
-      #   &(&1.id in socket.assigns.selected_contacts))
-
       contacts = Enum.filter(socket.assigns.contacts, &(&1.id in socket.assigns.selected_contacts))
 
       email_params = Map.put(email_params, "email_type", "bulk")

--- a/lib/email_notification_system_web/live/profile_live.ex
+++ b/lib/email_notification_system_web/live/profile_live.ex
@@ -1,8 +1,6 @@
 defmodule EmailNotificationSystemWeb.ProfileLive do
   use EmailNotificationSystemWeb, :live_view
 
-  # alias EmailNotificationSystem.Accounts
-
   def mount(_params, _session, socket) do
     {:ok, assign(socket, page_title: "Profile")}
   end


### PR DESCRIPTION
In this pull request, I make the buttons that enables a superuser to grant/revoke superuser rights to an exiting admin visible in the UI.